### PR TITLE
Fix HW+ selection and MPV audio handoff

### DIFF
--- a/app/src/main/java/app/infinity/mpvz/ui/browser/networkstreaming/NetworkBrowserViewModel.kt
+++ b/app/src/main/java/app/infinity/mpvz/ui/browser/networkstreaming/NetworkBrowserViewModel.kt
@@ -45,7 +45,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import java.net.URI
 
 /**
  * ViewModel for browsing files on a network share
@@ -264,7 +263,9 @@ class NetworkBrowserViewModel(
     connection: NetworkConnection,
   ): NetworkPath? =
     runCatching {
-      val uri = URI(rawUri)
+      // Android Uri accepts literal spaces and decodes percent-encoded path segments. Java URI
+      // rejects a WebDAV filename containing a literal space before we can normalize it.
+      val uri = Uri.parse(rawUri)
       val expectedScheme =
         when (connection.protocol) {
           NetworkProtocol.SMB -> "smb"
@@ -273,8 +274,8 @@ class NetworkBrowserViewModel(
         }
       if (!uri.scheme.equals(expectedScheme, ignoreCase = true) ||
         !uri.host.equals(connection.host.trim('[', ']'), ignoreCase = true) ||
-        uri.rawQuery != null ||
-        uri.rawFragment != null
+        uri.query != null ||
+        uri.fragment != null
       ) {
         return@runCatching null
       }

--- a/app/src/main/java/app/infinity/mpvz/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/infinity/mpvz/ui/player/PlayerActivity.kt
@@ -4892,6 +4892,11 @@ class PlayerActivity :
       if (!isAudioLoad) {
         // Apply track selection logic (defaults only apply when no saved state)
         trackSelector.onFileLoaded(hasState)
+        // A previous MPV session can leave the process-wide mute property enabled. Reactivate
+        // audio after saved state and track selection so reopening the same video is audible.
+        if (playbackEngine == PlaybackEngine.MPV) {
+          runCatching { PlaybackSession.setPropertyBoolean("mute", false) }
+        }
 
         // Apply default zoom only if there's no saved state
         if (!hasState) {

--- a/app/src/main/java/app/infinity/mpvz/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/infinity/mpvz/ui/player/PlayerActivity.kt
@@ -2230,6 +2230,9 @@ class PlayerActivity :
         // same delayed boundary used for the handoff seek so the visible MPV surface is live.
         delay(300L)
         if (playbackEngine == PlaybackEngine.MPV) {
+          // Native and MPV use different track identifiers. Re-select MPV's automatic audio
+          // track after a Native handoff so an invalid Native track id cannot leave MPV silent.
+          runCatching { PlaybackSession.setPropertyString("aid", "auto") }
           runCatching { PlaybackSession.setPropertyBoolean("pause", false) }
           if (resumePositionMs > 0L) {
             runCatching {

--- a/app/src/main/java/app/infinity/mpvz/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/app/infinity/mpvz/ui/player/PlayerActivity.kt
@@ -521,6 +521,8 @@ class PlayerActivity :
   private var media3PreparedItemId: String? = null
   /** True when MPV was fully stopped so Media3 could exclusively own the current item. */
   private var mpvStoppedForMedia3 = false
+  /** Re-select MPV's audio track after a Native-to-MPV handoff and saved-state restoration. */
+  @Volatile private var forceMpvAudioTrackAutoOnNextLoad = false
   private var media3VideoFrameRendered = false
   private var media3AutoFallbackItemId: String? = null
   private var activePlaybackItem: PlaybackItem? = null
@@ -2185,6 +2187,7 @@ class PlayerActivity :
       )
     }
 
+    forceMpvAudioTrackAutoOnNextLoad = playbackEngine == PlaybackEngine.MEDIA3
     AppDebugLog.info(
       TAG,
       "Playback engine selected engine=MPV " +
@@ -2246,6 +2249,9 @@ class PlayerActivity :
           // A seek started during the handoff can nest a second mute guard inside the replacement
           // guard. Complete both in one place so MPV does not remain silent after Media3 stops.
           PlaybackSession.restorePlaybackAudioAfterTransition()
+          // Media3 can leave MPV muted while it owns the audio output. Explicitly reopen MPV audio
+          // after the handoff so the old muted state cannot survive into the new engine session.
+          runCatching { PlaybackSession.setPropertyBoolean("mute", false) }
           AppDebugLog.info(
             TAG,
             "MPV handoff resumed item=${currentItem.stableId} positionMs=$resumePositionMs audioRestored=true",
@@ -4875,6 +4881,13 @@ class PlayerActivity :
           loadGeneration = loadGeneration,
         )
       if (!PlaybackSession.isCurrentGeneration(loadGeneration)) return@launch
+
+      // Native and MPV use different audio-track identifiers. Saved state is loaded asynchronously
+      // and can otherwise overwrite the MPV handoff's automatic track with a Native-only id.
+      if (playbackEngine == PlaybackEngine.MPV && forceMpvAudioTrackAutoOnNextLoad) {
+        runCatching { PlaybackSession.setPropertyString("aid", "auto") }
+        forceMpvAudioTrackAutoOnNextLoad = false
+      }
 
       if (!isAudioLoad) {
         // Apply track selection logic (defaults only apply when no saved state)

--- a/app/src/main/java/app/infinity/mpvz/ui/player/controls/components/sheets/SubtitleTracksSheet.kt
+++ b/app/src/main/java/app/infinity/mpvz/ui/player/controls/components/sheets/SubtitleTracksSheet.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -522,7 +523,7 @@ fun SubtitlesSheet(
               }
             }
             SubtitleItem.Divider -> {
-              HorizontalDivider(
+              Divider(
                 modifier =
                   Modifier.padding(
                     horizontal = MaterialTheme.spacing.medium,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio track restoration when switching playback modes, preventing incorrect track selections and ensuring MPV audio is unmuted after the transition.
  - Fixed network streaming path handling so WebDAV paths containing literal spaces are accepted correctly.

- **Style**
  - Updated separators in the subtitle track list for a more consistent interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->